### PR TITLE
[syntax] change Cyrillic Capital Pe to Greek Capital Pi

### DIFF
--- a/docs/language.rst
+++ b/docs/language.rst
@@ -102,7 +102,7 @@ Types and Kinds
       : | "(" "A" `type` `shape` ")"
       : | "(" ("->" | "→") "(" `type` ... ")" `type` ")"
       : | "(" ("Forall" | "∀") "(" `type_var` ... ")" `type` ")"
-      : | "(" ("Pi" | "П")  "(" `idx_var` ... ")" `type` ")"
+      : | "(" ("Pi" | "Π")  "(" `idx_var` ... ")" `type` ")"
       : | "(" ("Sigma" | "Σ") "(" `idx_var` ... ")" `type` ")"
    base_type : "Int" | "Bool" | "Float"
 

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -111,7 +111,7 @@ keywords =
     "Forall",
     "∀",
     "Pi",
-    "П",
+    "Π",
     "Sigma",
     "Σ",
     "let",
@@ -194,7 +194,7 @@ pType =
                     )
                 <*> pType,
               TEPi
-                <$> ( (lKeyword "Pi" <|> lKeyword "П")
+                <$> ( (lKeyword "Pi" <|> lKeyword "Π")
                         >> listOf pExtentParam
                     )
                 <*> pType,


### PR DESCRIPTION
They look the same, but when parsing the Greek Pi is more standard.