### PR TITLE
enable `remora futhark ... --backend=c` in `nix shell`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
               installPhase = ''
                 mkdir -p $out/bin
                 makeWrapper $src/bin/remora $out/bin/remora \
-                  --prefix PATH : "${pkgs.z3}/bin"
+                  --prefix PATH : "${pkgs.z3}/bin:${pkgs.futhark}/bin"
               '';
             };
             remora-docs = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
A simple change to let you do
```
remora futhark -f tests/basic0.remora --backend=c
```
from within `nix shell`.
