### PR TITLE
Use Futhark from upstream repository.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,56 @@
         "type": "github"
       }
     },
+    "futhark": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783110164,
+        "narHash": "sha256-PKpEyjFcs/+t6m5FEPi8dqipD2ZJDnW92+ZfPVgkLp0=",
+        "owner": "diku-dk",
+        "repo": "futhark",
+        "rev": "cd6a4070c8d8c7dc465b31029e29c1dc5501cc67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "diku-dk",
+        "repo": "futhark",
+        "type": "github"
+      }
+    },
+    "futhark-manifest": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782410341,
+        "narHash": "sha256-4vreJyA1hkr4tvJr1/IJftJqwJE3u1HdWO5oj1zXqQ0=",
+        "owner": "diku-dk",
+        "repo": "futhark-manifest-haskell",
+        "rev": "767c9bd7f71e11e7bb957a7b9782ce0c04867b40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "diku-dk",
+        "ref": "v1.9.0.0",
+        "repo": "futhark-manifest-haskell",
+        "type": "github"
+      }
+    },
+    "futhark-server": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778774324,
+        "narHash": "sha256-Sbo7uwoHrRc1JSOO859Wb5zbkXmLC2WZMRN5gaVlRuQ=",
+        "owner": "diku-dk",
+        "repo": "futhark-server-haskell",
+        "rev": "d39ac35f11a0efbb21a2dff90e57c86559ecae18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "diku-dk",
+        "ref": "v1.4.1.0",
+        "repo": "futhark-server-haskell",
+        "type": "github"
+      }
+    },
     "haskell-flake": {
       "locked": {
         "lastModified": 1782609638,
@@ -67,6 +117,9 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "futhark": "futhark",
+        "futhark-manifest": "futhark-manifest",
+        "futhark-server": "futhark-server",
         "haskell-flake": "haskell-flake",
         "nixpkgs": "nixpkgs",
         "sbv": "sbv"
@@ -75,11 +128,11 @@
     "sbv": {
       "flake": false,
       "locked": {
-        "lastModified": 1782936072,
-        "narHash": "sha256-SddAKMUsEEOOtNPbcWsEv+5dAAZSU7jONfnXkqOQkaM=",
+        "lastModified": 1783109314,
+        "narHash": "sha256-4WTWTtj6JjN6QDxzYm/jJk6m/n5vvdZwQtju4/Vwyv0=",
         "owner": "LeventErkok",
         "repo": "sbv",
-        "rev": "1a5e65ca0e64f4d9433080e90e93bab1269bc470",
+        "rev": "ff371e7a5c528b1f8ab2b99dd3ce744d58c55d1f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,18 @@
       url = "github:LeventErkok/sbv";
       flake = false;
     };
+    futhark = {
+      url = "github:diku-dk/futhark";
+      flake = false;
+    };
+    futhark-server = {
+      url = "github:diku-dk/futhark-server-haskell/v1.4.1.0";
+      flake = false;
+    };
+    futhark-manifest = {
+      url = "github:diku-dk/futhark-manifest-haskell/v1.9.0.0";
+      flake = false;
+    };
   };
   outputs =
     inputs@{ nixpkgs, flake-parts, ... }:
@@ -30,8 +42,15 @@
 
           haskellProjects.default = {
             packages.sbv.source = inputs.sbv;
+            packages.futhark.source = inputs.futhark;
+            packages.lsp.source = "2.8.0.0";
+            packages.lsp-types.source = "2.4.0.0";
+            packages.lsp-test.source = "0.18.0.0";
+            packages.futhark-server.source = inputs.futhark-server;
+            packages.futhark-manifest.source = inputs.futhark-manifest;
             settings.sbv.check = false;
             settings.remora.check = false;
+            settings.lsp-test.check = false;
             devShell = {
               tools = _: { inherit (pkgs) z3 nixfmt futhark cudatoolkit; };
               hlsCheck.enable = true;

--- a/remora.cabal
+++ b/remora.cabal
@@ -61,7 +61,7 @@ library
       process,
       filepath,
       sbv,
-      futhark == 0.25.37
+      futhark
 
     hs-source-dirs:   src
 

--- a/src/Futhark.hs
+++ b/src/Futhark.hs
@@ -537,15 +537,15 @@ compileBind (BindFun f params _ body (Info ret) _) = do
             F.entryParamUniqueness = F.Nonunique,
             F.entryParamType = F.TypeTransparent $ valueType (F.paramType p)
           }
-  let entryResults =
-        [ F.EntryResult
-            { F.entryResultUniqueness = F.Nonunique,
-              F.entryResultType = F.TypeTransparent $ valueType ret'
-            }
-        ]
+  let entryResult =
+        F.EntryResult
+          { F.entryResultUniqueness = F.Nonunique,
+            F.entryResultType = F.TypeTransparent $ valueType ret'
+          }
+
   let fun =
         F.FunDef
-          { F.funDefEntryPoint = Just (F.nameFromText $ varName f, map mkEntryParam params', entryResults),
+          { F.funDefEntryPoint = Just (F.nameFromText $ varName f, map mkEntryParam params', entryResult, Nothing),
             F.funDefAttrs = mempty,
             F.funDefName = F.nameFromText $ varName f,
             F.funDefRetType = [(F.toDecl (F.staticShapes1 ret') F.Nonunique, mempty)],
@@ -585,10 +585,10 @@ wrapInMain ((e, ret), State stms counter funs _) =
                              Just
                                ( "main",
                                  [],
-                                 [ F.EntryResult F.Nonunique $
-                                     F.TypeTransparent $
-                                       valueType ret
-                                 ]
+                                 F.EntryResult F.Nonunique $
+                                   F.TypeTransparent $
+                                     valueType ret,
+                                 Nothing
                                ),
                            F.funDefAttrs = mempty,
                            F.funDefName = "entry_main",


### PR DESCRIPTION
This allows us complete control over which version of Futhark is used, and we can even use specific commits or branches, which will likely become relevant.

For some reason, the automation cannot fetch futhark-manifest and futhark-server from Hackage just using the version numbers.

This needs to be manually kept in sync with what goes in cabal.project (right now there's nothing, so it's very fragile).

Fixes #16.